### PR TITLE
Introduce Router interface

### DIFF
--- a/src/main/kotlin/com/google/actions/api/ActionsSdkApp.kt
+++ b/src/main/kotlin/com/google/actions/api/ActionsSdkApp.kt
@@ -58,4 +58,6 @@ open class ActionsSdkApp : DefaultApp() {
                 userStorage = request.userStorage)
         return responseBuilder
     }
+
+    override fun router() = AnnotationRouter(this)
 }

--- a/src/main/kotlin/com/google/actions/api/AnnotationRouter.kt
+++ b/src/main/kotlin/com/google/actions/api/AnnotationRouter.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.actions.api
+
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CompletableFuture
+
+class AnnotationRouter(private val targetObject: Any) : Router {
+
+    val errorMsg_badReturnValue = "The return value of an intent handler" +
+        " must be ActionResponse or CompletableFuture<ActionResponse>"
+
+    private companion object {
+        val LOG = LoggerFactory.getLogger(AnnotationRouter::class.java.name)
+    }
+
+    override fun route(request: ActionRequest): CompletableFuture<ActionResponse> {
+        val intent = request.intent
+        val forIntentType = ForIntent::class.java
+        for (method in targetObject.javaClass.declaredMethods) {
+            if (method.isAnnotationPresent(forIntentType)) {
+                val annotation = method.getAnnotation(forIntentType)
+                val forIntent = annotation as ForIntent
+                if (forIntent.value == intent) {
+                    val result = method.invoke(targetObject, request)
+                    return if (result is ActionResponse) {
+                        CompletableFuture.completedFuture(result)
+                    } else if (result is CompletableFuture<*>) {
+                        result as CompletableFuture<ActionResponse>
+                    } else {
+                        LOG.warn(errorMsg_badReturnValue)
+                        throw Exception(errorMsg_badReturnValue)
+                    }
+                }
+            }
+        }
+        // Unable to find a method with the annotation matching the intent.
+        LOG.warn("Intent handler not found: {}", intent)
+        throw Exception("Intent handler not found - $intent")
+    }
+}

--- a/src/main/kotlin/com/google/actions/api/DialogflowApp.kt
+++ b/src/main/kotlin/com/google/actions/api/DialogflowApp.kt
@@ -56,4 +56,6 @@ open class DialogflowApp : DefaultApp() {
                 userStorage = request.userStorage)
         return responseBuilder
     }
+
+    override fun router(): Router = AnnotationRouter(this)
 }

--- a/src/main/kotlin/com/google/actions/api/Router.kt
+++ b/src/main/kotlin/com/google/actions/api/Router.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.actions.api
+
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Returns response for a given ActionRequest
+ */
+interface Router {
+    @Throws(Exception::class)
+    fun route(request: ActionRequest): CompletableFuture<ActionResponse>
+}

--- a/src/test/kotlin/com/google/actions/api/DialogflowRequestTest.kt
+++ b/src/test/kotlin/com/google/actions/api/DialogflowRequestTest.kt
@@ -17,7 +17,6 @@
 package com.google.actions.api
 
 import com.google.actions.api.impl.DialogflowRequest
-import com.google.actions.api.response.ResponseBuilder
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import org.junit.Assert.assertEquals
@@ -152,7 +151,8 @@ class DialogflowRequestTest {
         val inputJson = Files.readAllLines(
                 Paths.get("src", "test", "resources",
                         "dialogflow_welcome.json")).joinToString("\n")
-        app.handleRequest(inputJson, null)
+        val result = app.handleRequest(inputJson, null).get()
+        assertNotNull(result)
     }
 
     internal inner class MyDialogflowApp : DialogflowApp() {


### PR DESCRIPTION
Router interface allows library users to provide their own router implementations - eg. predicate based router or their own annotations (can fix https://github.com/actions-on-google/actions-on-google-java/issues/31 for instance)