### PR TITLE
Close channel after getting a response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ gradlew.bat
 out/
 .DS_Store
 src/generated # Generated source files
+local-repo/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,16 @@ accept your pull requests.
    recommended coding standards for this organization.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
 1. Submit a pull request.
+
+## Compiling Locally
+
+1. Use Java 8 for compilation. Otherwise compilation will fail while looking for `javax.annotation.Generated`.
+
+1. Install bundled jars to the local repository:
+
+       mvn install:install-file@install-actions-bindings
+       mvn install:install-file@install-dialogflow-bindings
+
+1. Compile the project:
+
+       mvn compile


### PR DESCRIPTION
This fixes the following errors from the logs:

```
Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
```

This fix was originally mentioned in https://github.com/actions-on-google/actions-on-google-java/issues/30#issuecomment-529400776

I have also published this change to [my bintray repository](https://bintray.com/2m/maven/actions-on-google/1.8.0-2m) so I can use this fix in https://github.com/actions-on-google/smart-home-java

If anyone else is interested, you can also use it by adding the following to the gradle build:

```
repositories {
  maven {
    url 'http://dl.bintray.com/2m/maven'
  }
}

dependencies {
  implementation 'com.google.actions:actions-on-google:1.8.0-2m'
}
```